### PR TITLE
Shave binary down from 112 bytes to 110 bytes;

### DIFF
--- a/src/main.zen
+++ b/src/main.zen
@@ -8,8 +8,7 @@ export fn main() callconv(.C) i32 {
         ij.locate(x, 5);
         ij.putc(236);
         ij.locate(ij.rnd(32), 23);
-        ij.putc('*');
-        ij.putc(10);
+        ij.putc(.{'*', 10});
         ij.wait(3);
         switch (ij.inkey()) {
             28 => x -= 1,

--- a/src/std15.zen
+++ b/src/std15.zen
@@ -10,10 +10,16 @@ pub fn sin(x: i32) i32 {
     return f(x);
 }
 
-pub fn putc(x: u8) void {
+pub fn putc(x: anytype) void {
     const addr = @intToPtr(*u16, 0xC4);
     const f = @intToPtr(fn(u8) void, addr.*);
-    f(x);
+    if (@typeInfo(@TypeOf(x)) != .Struct) {
+        f(x);
+    } else {
+        inline for (x) |c| {
+            f(c);
+        }
+    }
 }
 
 pub fn putnum(x: i32) void {


### PR DESCRIPTION
By making `std15.putc` a generic fn that can accept multiple arguments, we can remove an unnecessary load instruction:

```diff
67,68c67
< 	blx	r1
< 	ldrh	r1, [r6]
---
> 	blx	r6
```

```sh
$ zen build-exe src/main.zen --name new/zen4ij -target thumb-freestanding-eabi -mcpu cortex-m0 --strip --release-small --linker-script memory.x --emit asm

ConnectFree(R) Zen(R) Language Compiler 0.9.20200713i-8-g6a4b350c
Copyright (C) ConnectFree Corporation. All Rights Reserved.
Online Documentation: https://zen-lang.org/ja-JP/docs/

* Wrote BIN:  ./new/zen4ij
* Wrote ASM:  ./new/zen4ij.s

$ llvm-objcopy -S ./new/zen4ij -g -O binary --only-section=.text new/zen4ij.bin

$ wc -c ./new/zen4ij.bin
     110 ./new/zen4ij.bin
```